### PR TITLE
Added the WITH command used in the CTE syntax.

### DIFF
--- a/src/main/java/org/servantscode/commons/search/QueryBuilder.java
+++ b/src/main/java/org/servantscode/commons/search/QueryBuilder.java
@@ -185,7 +185,7 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
         }
 
         StringBuilder sql = new StringBuilder();
-        if(!with.isEmpty())
+        if(isSet(with))
             sql.append("WITH ").append(with).append(" ");
         sql.append("SELECT ");
         if(distinct)

--- a/src/main/java/org/servantscode/commons/search/QueryBuilder.java
+++ b/src/main/java/org/servantscode/commons/search/QueryBuilder.java
@@ -17,7 +17,7 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
 
     private enum BuilderState {START, WITH_CTE, SELECT, FROM, JOIN, WHERE, GROUP, SORT, LIMIT, OFFSET, DONE};
 
-    private List<String> with = new LinkedList<>();
+    private String with = null;
     private List<String> selections = new LinkedList<>();
     private List<String> tables = new LinkedList<>();
     private List<String> joins = new LinkedList<>();
@@ -33,13 +33,14 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
     public QueryBuilder() {
     }
 
-    public QueryBuilder withCte(String... with){
-        return withCte(asList(with));
-    }
 
-    public QueryBuilder withCte(List<String> with) {
+    public QueryBuilder withCte(String with, Object... values) {
+        return withCte(with, asList(values));
+    }
+    public QueryBuilder withCte(String with, List<Object> values){
         setState(BuilderState.WITH_CTE);
-        this.with.addAll(with);
+        this.with = with;
+        this.values.add(values);
         return this;
     }
 
@@ -185,9 +186,7 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
 
         StringBuilder sql = new StringBuilder();
         if(!with.isEmpty())
-            sql.append("WITH ")
-                    .append(String.join(" ", with))
-                    .append(" ");
+            sql.append("WITH ").append(with);
         sql.append("SELECT ");
         if(distinct)
             sql.append("DISTINCT ");
@@ -204,7 +203,7 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
         if(!groupBy.isEmpty())
             sql.append(" GROUP BY ").append(String.join(", ", groupBy));
         if(isSet(sort))
-            sql.append(" ORDER BY " + sort);
+            sql.append(" ORDER BY ").append(sort);
         if(limit)
             sql.append(" LIMIT ?");
         if(offset)

--- a/src/main/java/org/servantscode/commons/search/QueryBuilder.java
+++ b/src/main/java/org/servantscode/commons/search/QueryBuilder.java
@@ -2,7 +2,6 @@ package org.servantscode.commons.search;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -16,8 +15,9 @@ import static org.servantscode.commons.StringUtils.isSet;
 public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
     private static Logger LOG = LogManager.getLogger(QueryBuilder.class);
 
-    private enum BuilderState {START, SELECT, FROM, JOIN, WHERE, GROUP, SORT, LIMIT, OFFSET, DONE};
+    private enum BuilderState {START, WITH_CTE, SELECT, FROM, JOIN, WHERE, GROUP, SORT, LIMIT, OFFSET, DONE};
 
+    private List<String> with = new LinkedList<>();
     private List<String> selections = new LinkedList<>();
     private List<String> tables = new LinkedList<>();
     private List<String> joins = new LinkedList<>();
@@ -33,6 +33,15 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
     public QueryBuilder() {
     }
 
+    public QueryBuilder withCte(String... with){
+        return withCte(asList(with));
+    }
+
+    public QueryBuilder withCte(List<String> with) {
+        setState(BuilderState.WITH_CTE);
+        this.with.addAll(with);
+        return this;
+    }
 
     public QueryBuilder select(String... selections) {
         return select(asList(selections));
@@ -175,6 +184,10 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
         }
 
         StringBuilder sql = new StringBuilder();
+        if(!with.isEmpty())
+            sql.append("WITH ")
+                    .append(String.join(" ", with))
+                    .append(" ");
         sql.append("SELECT ");
         if(distinct)
             sql.append("DISTINCT ");

--- a/src/main/java/org/servantscode/commons/search/QueryBuilder.java
+++ b/src/main/java/org/servantscode/commons/search/QueryBuilder.java
@@ -186,7 +186,7 @@ public class QueryBuilder extends FilterableBuilder<QueryBuilder> {
 
         StringBuilder sql = new StringBuilder();
         if(!with.isEmpty())
-            sql.append("WITH ").append(with);
+            sql.append("WITH ").append(with).append(" ");
         sql.append("SELECT ");
         if(distinct)
             sql.append("DISTINCT ");

--- a/src/main/java/org/servantscode/commons/search/UpdateBuilder.java
+++ b/src/main/java/org/servantscode/commons/search/UpdateBuilder.java
@@ -2,26 +2,35 @@ package org.servantscode.commons.search;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.filter.Filterable;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.servantscode.commons.StringUtils.isSet;
+
 public class UpdateBuilder extends FilterableBuilder<UpdateBuilder> {
     private static Logger LOG = LogManager.getLogger(UpdateBuilder.class);
 
-    private enum BuilderState { START, TABLE, JOIN, VALUES, WHERE, DONE };
+    private enum BuilderState { START, WITH, TABLE, JOIN, VALUES, WHERE, DONE };
 
     private String table = null;
+    private String with = null;
     private List<String> fields = new LinkedList<>();
     private List<String> joins = new LinkedList<>();
 
     private BuilderState state = BuilderState.START;
 
     public UpdateBuilder() {}
+
+    public UpdateBuilder withCte(String with, Object... values) {
+        setState(BuilderState.WITH);
+        this.with = with;
+        this.values.addAll(Arrays.asList(values));
+        return this;
+    }
+
 
     public UpdateBuilder update(String table) {
         setState(BuilderState.TABLE);
@@ -57,6 +66,8 @@ public class UpdateBuilder extends FilterableBuilder<UpdateBuilder> {
         }
 
         StringBuilder sql = new StringBuilder();
+        if(isSet(with))
+            sql.append("WITH ").append(with).append(" ");
         sql.append("UPDATE ").append(table);
         if(!joins.isEmpty())
             sql.append(" ").append(String.join(" ", joins));

--- a/src/test/java/org/servantscode/commons/QueryBuilderTest.java
+++ b/src/test/java/org/servantscode/commons/QueryBuilderTest.java
@@ -12,7 +12,7 @@ public class QueryBuilderTest {
         QueryBuilder queryBuilder = new QueryBuilder();
         String sql = queryBuilder.withCte("table1").select("e.id").from("entity e").getSql();
 
-        assertEquals(sql, "WITH table1 SELECT e.id FROM entity e");
+        assertEquals("WITH table1 SELECT e.id FROM entity e", sql);
     }
 
 }

--- a/src/test/java/org/servantscode/commons/QueryBuilderTest.java
+++ b/src/test/java/org/servantscode/commons/QueryBuilderTest.java
@@ -1,0 +1,18 @@
+package org.servantscode.commons;
+
+import org.junit.Test;
+import org.servantscode.commons.search.QueryBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryBuilderTest {
+
+    @Test
+    public void testWithCte(){
+        QueryBuilder queryBuilder = new QueryBuilder();
+        String sql = queryBuilder.withCte("table1").select("e.id").from("entity e").getSql();
+
+        assertEquals(sql, "WITH table1 SELECT e.id FROM entity e");
+    }
+
+}

--- a/src/test/java/org/servantscode/commons/UpdateBuilderTest.java
+++ b/src/test/java/org/servantscode/commons/UpdateBuilderTest.java
@@ -1,0 +1,18 @@
+package org.servantscode.commons;
+
+import org.junit.Test;
+import org.servantscode.commons.search.UpdateBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateBuilderTest {
+
+    @Test
+    public void testWithCte(){
+        UpdateBuilder updateBuilder = new UpdateBuilder();
+        String sql = updateBuilder.withCte("table1").update("entity").getSql();
+
+        assertEquals(sql, "WITH table1 UPDATE entity");
+    }
+
+}


### PR DESCRIPTION
A common table expression (CTE), is a temporary named result set created from a simple SELECT statement that can be used in a subsequent SELECT statement. Each SQL CTE is like a named query, whose result is stored in a virtual table (a CTE) to be referenced later in the main query.